### PR TITLE
Improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
-# seminarverwaltung
+# Seminarverwaltung
 
-Frontend: Julian Hofer, Armin Gross, Felix Welscher
-Backend: Simon Mairhofer, Roberth Matha, Benjamin Matscher, Argtim Gashi
+> Verwaltung von Seminaren – Teamübersicht & Projektinfo
 
-Product Owner: Roberth Matha, Julian Fink
+## Team (Version 1)
 
-For planning and current Project State: -> www.taiga.io
+**Frontend**
+- Julian Hofer
+- Armin Gross
+- Felix Welscher
 
+**Backend**
+- Simon Mairhofer
+- Roberth Matha
+- Benjamin Matscher
+- Argtim Gashi
 
-# seminarverwaltung 2.0
+**Product Owner**
+- Roberth Matha
+- Julian Fink
 
-Team: Luca Riggio, Daniel Zwischenbrugger, Armin Gross, Codalonga Andreas, Hermeter David
+## Planung & Projektstatus
+- Taiga: https://www.taiga.io
+
+---
+
+## Seminarverwaltung 2.0
+
+**Team**
+- Luca Riggio
+- Daniel Zwischenbrugger
+- Armin Gross
+- Codalonga Andreas
+- Hermeter David


### PR DESCRIPTION
### Motivation
- Improve the `README.md` readability and structure for contributors and reviewers.
- Separate team attribution from project planning information to make roles clearer.
- Add a concise project tagline and modernize header capitalization for a cleaner presentation.

### Description
- Rewrote `README.md` to use a top-level title, a tagline blockquote, and clearer section headings.
- Converted flat contributor lines into categorized bulleted lists for `Frontend`, `Backend`, and `Product Owner`.
- Added a `Planung & Projektstatus` section with a formatted Taiga link and an `Seminarverwaltung 2.0` team subsection with listed members.
- Performed minor text and capitalization cleanup for consistent style.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602b1b08288331a1c12ddc244e4fee)